### PR TITLE
1.5.0 dev clustered modal

### DIFF
--- a/src/data/selectors/index.js
+++ b/src/data/selectors/index.js
@@ -965,10 +965,12 @@ export const selectNodeClusters = createSelector(
           colorDomain: null,
           sizeDomain: null,
           icon: d['icon'],
+          grouped_ids: [d.id],
           ...R.mergeDeepRight(colorPropObj, sizePropObj),
         }
       },
       reduce: (acc, dProps) => {
+        const id = dProps.grouped_ids
         const colorProp = getVarByProp('colorBy', dProps)
         const sizeProp = getVarByProp('sizeBy', dProps)
         if (sizeProp) {
@@ -984,6 +986,10 @@ export const selectNodeClusters = createSelector(
         if (colorProp && colorProp !== sizeProp) {
           const propValue = dProps[colorProp].value
           acc[colorProp].value = acc[colorProp].value.concat(propValue)
+        }
+        // all the ids of the points grouped in this cluster
+        if (id) {
+          acc.grouped_ids = acc.grouped_ids.concat(id)
         }
       },
     }

--- a/src/ui/compound/ClusterModal.js
+++ b/src/ui/compound/ClusterModal.js
@@ -1,0 +1,219 @@
+import { Box, Modal, Typography } from '@mui/material'
+import Paper from '@mui/material/Paper'
+import Table from '@mui/material/Table'
+import TableBody from '@mui/material/TableBody'
+import TableCell from '@mui/material/TableCell'
+import TableContainer from '@mui/material/TableContainer'
+import TableHead from '@mui/material/TableHead'
+import TablePagination from '@mui/material/TablePagination'
+import TableRow from '@mui/material/TableRow'
+import PropTypes from 'prop-types'
+import * as R from 'ramda'
+import * as React from 'react'
+import { useEffect, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+
+import { openMapModal, closeMapModal } from '../../data/local/mapSlice'
+import {
+  selectAppBarId,
+  selectNodeClustersAtZoom,
+  selectNodeData,
+} from '../../data/selectors'
+
+const styles = {
+  modal: {
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    width: 'auto',
+    color: 'text.primary',
+    bgcolor: 'background.paper',
+    border: 1,
+    borderRadius: 1,
+    borderColor: 'text.primary',
+    boxShadow: 24,
+    p: 3,
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+  },
+  title: {
+    p: 0.5,
+    mb: 2,
+    whiteSpace: 'nowrap',
+  },
+}
+
+const ClusterModal = ({ title, cluster_id, ...props }) => {
+  const dispatch = useDispatch()
+  const appBarId = useSelector(selectAppBarId)
+
+  const groupedNodesAtZoom = useSelector(selectNodeClustersAtZoom)
+  // can't get the Rambda to work :(
+  // const targetCluster = R.find(R.and(R.path(['properties', 'cluster']),
+  //                                    R.pathEq(cluster_id, ['properties', 'cluster_id']),
+  //                                    R.pathEq(title, ['properties', 'type'])))(groupedNodesAtZoom.data)
+
+  // get clicked cluster
+  let targetCluster = undefined
+  for (const node of groupedNodesAtZoom.data) {
+    if (
+      node.properties.cluster &&
+      node.properties.cluster_id === cluster_id &&
+      node.properties.type === title
+    ) {
+      targetCluster = node
+      break
+    }
+  }
+
+  // get all nodes in cluster
+  const grouped_ids = new Set(targetCluster.properties.grouped_ids)
+  const nodeData = useSelector(selectNodeData).filter((node) =>
+    grouped_ids.has(node[0])
+  ) //.map(node => node[1])
+
+  // generate table columns for given cluster's props
+  const tableColumns = [{ id: 'name', label: 'Name', minWidth: 170 }]
+  for (const prop of Object.keys(nodeData[0][1].props)) {
+    tableColumns.push({ id: prop, label: prop, minWidth: 170, align: 'right' })
+  }
+
+  // generate table rows for given cluster's node data
+  const createData = (node) => {
+    const data = { name: node[0] }
+    for (const prop of Object.keys(node[1].props)) {
+      data[prop] = node[1].props[prop].value.toString()
+    }
+    return data
+  }
+  const tableRows = nodeData.map((node) => createData(node))
+
+  const [openTime, setOpenTime] = useState(undefined)
+
+  // store the time the modal was opened to prevent closing instantly in touch mode
+  useEffect(() => {
+    setOpenTime(new Date().getTime())
+  }, [])
+
+  const StickyHeadTable = (rows, columns) => {
+    const [page, setPage] = React.useState(0)
+    const [rowsPerPage, setRowsPerPage] = React.useState(10)
+
+    const handleChangePage = (event, newPage) => {
+      setPage(newPage)
+    }
+
+    const handleChangeRowsPerPage = (event) => {
+      setRowsPerPage(+event.target.value)
+      setPage(0)
+    }
+
+    return (
+      <Paper sx={{ width: '100%', overflow: 'hidden' }}>
+        <TableContainer sx={{ maxHeight: 440 }}>
+          <Table stickyHeader aria-label="sticky table">
+            <TableHead>
+              <TableRow>
+                {columns.map((column) => (
+                  <TableCell
+                    key={column.id}
+                    align={column.align}
+                    style={{ minWidth: column.minWidth }}
+                  >
+                    {column.label}
+                  </TableCell>
+                ))}
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {rows
+                .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+                .map((row) => {
+                  return (
+                    <TableRow
+                      hover
+                      onClick={() => {
+                        // get node data for clicked row
+                        const node = nodeData.filter(
+                          (node) => node[0] === row.name
+                        )[0]
+                        // open map modal with node data
+                        dispatch(
+                          openMapModal({
+                            appBarId,
+                            data: {
+                              ...node[1],
+                              feature: 'nodes',
+                              type: R.propOr(node[1].type, 'name')(node[1]),
+                              key: node[0],
+                            },
+                          })
+                        )
+                      }}
+                      role="checkbox"
+                      tabIndex={-1}
+                      key={row.name}
+                    >
+                      {columns.map((column) => {
+                        const value = row[column.id]
+                        return (
+                          <TableCell key={column.id} align={column.align}>
+                            {column.format && typeof value === 'number'
+                              ? column.format(value)
+                              : value}
+                          </TableCell>
+                        )
+                      })}
+                    </TableRow>
+                  )
+                })}
+            </TableBody>
+          </Table>
+        </TableContainer>
+        <TablePagination
+          rowsPerPageOptions={[10, 25, 100]}
+          component="div"
+          count={rows.length}
+          rowsPerPage={rowsPerPage}
+          page={page}
+          onPageChange={handleChangePage}
+          onRowsPerPageChange={handleChangeRowsPerPage}
+        />
+      </Paper>
+    )
+  }
+
+  return (
+    <Modal
+      disablePortal
+      disableEnforceFocus
+      disableAutoFocus
+      open
+      onClose={() => {
+        const currentTime = new Date().getTime()
+        if (currentTime - openTime > 500) dispatch(closeMapModal(appBarId))
+      }}
+      {...props}
+    >
+      <Box sx={styles.modal}>
+        <Box sx={styles.header}>
+          <Typography sx={styles.title} variant="h5">
+            Grouped {title}
+          </Typography>
+        </Box>
+        <Box sx={{ overflow: 'auto', maxHeight: '80vh', maxWidth: '90vw' }}>
+          {StickyHeadTable(tableRows, tableColumns)}
+        </Box>
+      </Box>
+    </Modal>
+  )
+}
+ClusterModal.propTypes = {
+  title: PropTypes.string,
+  children: PropTypes.node,
+}
+
+export default ClusterModal

--- a/src/ui/views/map/Map.js
+++ b/src/ui/views/map/Map.js
@@ -95,6 +95,9 @@ const Map = ({ mapboxToken }) => {
         x: R.prop('x', e),
         radius: 20,
       })
+      const pickedCluster = R.find(
+        R.pathEq(layerId.NODE_ICON_CLUSTER_LAYER, ['layer', 'id'])
+      )(pickedItems)
       const pickedNode = R.find(
         R.pathEq(layerId.NODE_ICON_LAYER, ['layer', 'id'])
       )(pickedItems)
@@ -103,7 +106,25 @@ const Map = ({ mapboxToken }) => {
           R.pathEq(layerId.ARC_LAYER, ['layer', 'id'], d) ||
           R.pathEq(layerId.ARC_LAYER_3D, ['layer', 'id'], d)
       )(pickedItems)
-      R.isNotNil(pickedNode)
+
+      R.isNotNil(pickedCluster)
+        ? dispatch(
+            openMapModal({
+              appBarId,
+              data: {
+                ...R.pathOr({}, ['object', 'properties'])(pickedCluster),
+                feature: 'nodes',
+                type: R.propOr(
+                  pickedCluster.object.properties.type,
+                  'name'
+                )(pickedCluster.object.properties),
+                key: pickedCluster.object.id
+                  ? `node${pickedCluster.object.id}`
+                  : pickedCluster.object.properties.id,
+              },
+            })
+          )
+        : R.isNotNil(pickedNode)
         ? dispatch(
             openMapModal({
               appBarId,

--- a/src/ui/views/map/MapModal.js
+++ b/src/ui/views/map/MapModal.js
@@ -32,6 +32,7 @@ import {
   selectAppBarId,
 } from '../../../data/selectors'
 import { styleId } from '../../../utils/enums'
+import ClusterModal from '../../compound/ClusterModal'
 import SimpleModal from '../../compound/SimpleModal'
 import { renderPropsLayout } from '../common/renderLayout'
 
@@ -86,6 +87,7 @@ const OnLayerEventModal = () => {
   const data = useSelector(selectData)
 
   const {
+    cluster_id,
     feature,
     type,
     key,
@@ -121,7 +123,17 @@ const OnLayerEventModal = () => {
     )
   }
 
-  return (
+  return R.isNotNil(cluster_id) ? (
+    <ClusterModal title={type} cluster_id={cluster_id}>
+      {renderPropsLayout({
+        layout,
+        items,
+        resolveTime,
+        getCurrentVal,
+        onChangeProp,
+      })}
+    </ClusterModal>
+  ) : (
     <SimpleModal title={name || type}>
       {renderPropsLayout({
         layout,


### PR DESCRIPTION
Add support for cluster modals. ClusterModal is a MUI-styled table with clickable rows corresponding to the nodes contained in the cluster. Clicking on a table row brings up the SimpleModal for the base node.

Example:
<img width="1512" alt="image" src="https://github.com/MIT-CAVE/cave_static/assets/97476527/12976c1c-d953-417a-b6a2-990a39043840">
