### PR TITLE
allow number formatting and overriding labels

### DIFF
--- a/src/ui/compound/GradientBox.js
+++ b/src/ui/compound/GradientBox.js
@@ -1,12 +1,8 @@
 /** @jsxImportSource @emotion/react */
 import * as R from 'ramda'
 
-import { serializeNumLabel } from '../../utils'
-
 export const getGradientBox = R.curry(
   (maxColor, minColor, maxLabel, minLabel) => {
-    const strMaxLabel = serializeNumLabel(maxLabel)
-    const strMinLabel = serializeNumLabel(minLabel)
     return (
       <div
         css={{
@@ -18,15 +14,14 @@ export const getGradientBox = R.curry(
         <div
           css={{
             width: '60px',
-            textAlign: 'left',
+            textAlign: 'center',
             marginRight: '10px',
             marginLeft: '10px',
             fontWeight: 700,
-            whiteSpace: 'nowrap',
             flex: 0,
           }}
         >
-          {strMinLabel}
+          {minLabel}
         </div>
         <div
           css={{
@@ -38,7 +33,7 @@ export const getGradientBox = R.curry(
         />
         <div
           css={{
-            textAlign: 'right',
+            textAlign: 'center',
             width: '60px',
             marginRight: '10px',
             marginLeft: '10px',
@@ -46,7 +41,7 @@ export const getGradientBox = R.curry(
             flex: 0,
           }}
         >
-          {strMaxLabel}
+          {maxLabel}
         </div>
       </div>
     )

--- a/src/ui/views/map/MapLegend.js
+++ b/src/ui/views/map/MapLegend.js
@@ -43,6 +43,7 @@ import {
   capitalize,
   customSort,
   eitherBoolOrNotNull,
+  formatNumber,
   includesPath,
   serializeNumLabel,
 } from '../../../utils'
@@ -152,6 +153,26 @@ const nonSx = {
 const addExtraProps = (Component, extraProps) => {
   const ComponentType = Component.type
   return <ComponentType {...Component.props} {...extraProps} />
+}
+
+const getMinMaxLabel = (valRange, timeProp, valProp, typeObj, end) => {
+  return R.pathOr(
+    R.path(['props', valProp, 'legendUseNumberFormat'])(typeObj)
+      ? formatNumber(
+          timeProp(end, valRange),
+          R.path(['props', valProp, 'numberFormat'])(typeObj)
+        )
+      : serializeNumLabel(timeProp(end, valRange)),
+    ['props', valProp, 'legendOverride', end]
+  )(typeObj)
+}
+
+const getMinLabel = (valRange, timeProp, valProp, typeObj) => {
+  return getMinMaxLabel(valRange, timeProp, valProp, typeObj, 'min')
+}
+
+const getMaxLabel = (valRange, timeProp, valProp, typeObj) => {
+  return getMinMaxLabel(valRange, timeProp, valProp, typeObj, 'max')
 }
 
 const CategoricalItems = ({ layerKey, colorRange, getLabel = capitalize }) =>
@@ -282,10 +303,10 @@ const MapLegendSizeBySection = ({
           sx={{
             mr: 1,
             fontWeight: 700,
-            whiteSpace: 'nowrap',
+            textAlign: 'center',
           }}
         >
-          {serializeNumLabel(timeProp('min', sizeRange))}
+          {getMinLabel(sizeRange, timeProp, sizeProp, typeObj)}
         </Box>
         <Box sx={{ mr: 0.75 }}>
           {addExtraProps(icon, {
@@ -303,8 +324,8 @@ const MapLegendSizeBySection = ({
             },
           })}
         </Box>
-        <Box sx={{ ml: 1, fontWeight: 700 }}>
-          {serializeNumLabel(timeProp('max', sizeRange))}
+        <Box sx={{ ml: 1, fontWeight: 700, textAlign: 'center' }}>
+          {getMaxLabel(sizeRange, timeProp, sizeProp, typeObj)}
         </Box>
       </Box>
     </>
@@ -415,8 +436,8 @@ const MapLegendGeoToggle = ({ geoType, typeObj, legendGroupId, colorProp }) => {
               ['endGradientColor', themeType],
               colorRange
             ),
-            maxVal: timeProp('max', colorRange),
-            minVal: timeProp('min', colorRange),
+            maxVal: getMaxLabel(colorRange, timeProp, colorProp, typeObj),
+            minVal: getMinLabel(colorRange, timeProp, colorProp, typeObj),
           }}
         />
       )}
@@ -681,13 +702,17 @@ const MapLegendNodeToggle = ({
                   ['endGradientColor', themeType],
                   colorRange
                 ),
-                maxVal: timeProp(
-                  'max',
-                  group && colorDomain ? colorDomain : colorRange
+                maxVal: getMaxLabel(
+                  group && colorDomain ? colorDomain : colorRange,
+                  timeProp,
+                  colorProp,
+                  typeObj
                 ),
-                minVal: timeProp(
-                  'min',
-                  group && colorDomain ? colorDomain : colorRange
+                minVal: getMinLabel(
+                  group && colorDomain ? colorDomain : colorRange,
+                  timeProp,
+                  colorProp,
+                  typeObj
                 ),
               }}
             />
@@ -860,8 +885,8 @@ const MapLegendArcToggle = ({
                   ['endGradientColor', themeType],
                   colorRange
                 ),
-                maxVal: timeProp('max', colorRange),
-                minVal: timeProp('min', colorRange),
+                maxVal: getMaxLabel(colorRange, timeProp, colorProp, typeObj),
+                minVal: getMinLabel(colorRange, timeProp, colorProp, typeObj),
               }}
             />
           )}


### PR DESCRIPTION
![image](https://github.com/MIT-CAVE/cave_static/assets/18196879/975c7fea-4c20-4563-a6ab-1c7ed27d6c0e)

This is one way we can address [Legend numberFormat for int if not using SciNotation](https://github.com/MIT-CAVE/cave_app/issues/82) and [Text labels for color gradients in legend](https://github.com/MIT-CAVE/cave_static/issues/234). I will add docs and an example to the static api if it makes sense to use it.

We add two keys to `props`

```
"legendUseNumberFormat": True,
"legendOverride": {
    "min": "Some Label",
    "max": "Another Label",
},
```

(This isn't a perfect example because the override would take precedence over using number format)

Legend override would have highest precedence and set fixed labels for the min and max. Legend use number format would load the values as `X units` and so forth. As an alternative to this, I could have a `legendNumberFormat` key and have all of the `numberFormat` keys, but specific to how the legend should format it.