### PR TITLE
2.3.0 dev session pane glitch

### DIFF
--- a/src/ui/views/common/SessionPane.js
+++ b/src/ui/views/common/SessionPane.js
@@ -739,6 +739,7 @@ const SessionPane = ({ width }) => {
         sx={{ py: 3 }}
       />
       <DataGrid
+        disableVirtualization
         sx={{
           '.MuiDataGrid-virtualScrollerRenderZone': {
             width: '97%',


### PR DESCRIPTION
Disabled virtualization for the DataGrid component containing the session cards to prevent glitching while scrolling. (Tested manually creating many sessions using data_gen.py and verified that performance is not noticeably impacted.)

Resolves #544 