### PR TITLE
3.0.0 dev chart hover order

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,8 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+    'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
+    'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/src/ui/charts/chart-types/echarts/BarPlot.js
+++ b/src/ui/charts/chart-types/echarts/BarPlot.js
@@ -10,12 +10,21 @@ const BarPlot = ({
   colors,
   stack = false,
   showNA,
+  chartHoverOrder,
 }) => {
   return (
     <EchartsPlot
       data={data}
       chartType="bar"
-      {...{ xAxisTitle, yAxisTitle, numberFormat, stack, colors, showNA }}
+      {...{
+        xAxisTitle,
+        yAxisTitle,
+        numberFormat,
+        stack,
+        colors,
+        showNA,
+        chartHoverOrder,
+      }}
     />
   )
 }

--- a/src/ui/charts/chart-types/echarts/BaseChart.js
+++ b/src/ui/charts/chart-types/echarts/BaseChart.js
@@ -176,12 +176,16 @@ const baseOptions = {
   },
 }
 
-const FlexibleChart = ({ options, ...props }) => {
+const FlexibleChart = ({ options, orderBySize, ...props }) => {
   return (
     <FlexibleContainer>
       <ReactEChartsCore
         echarts={echarts}
-        option={R.mergeDeepRight(baseOptions)(options)}
+        option={R.mergeDeepRight(
+          orderBySize
+            ? R.assocPath(['tooltip', 'order'], 'valueDesc', baseOptions)
+            : baseOptions
+        )(options)}
         notMerge
         theme="dark"
         // lazyUpdate

--- a/src/ui/charts/chart-types/echarts/BaseChart.js
+++ b/src/ui/charts/chart-types/echarts/BaseChart.js
@@ -176,15 +176,13 @@ const baseOptions = {
   },
 }
 
-const FlexibleChart = ({ options, orderBySize, ...props }) => {
+const FlexibleChart = ({ options, chartHoverOrder, ...props }) => {
   return (
     <FlexibleContainer>
       <ReactEChartsCore
         echarts={echarts}
         option={R.mergeDeepRight(
-          orderBySize
-            ? R.assocPath(['tooltip', 'order'], 'valueDesc', baseOptions)
-            : baseOptions
+          R.assocPath(['tooltip', 'order'], chartHoverOrder, baseOptions)
         )(options)}
         notMerge
         theme="dark"
@@ -206,6 +204,7 @@ const EchartsPlot = ({
   colors,
   distribution = false,
   showNA,
+  chartHoverOrder,
 }) => {
   if (R.isNil(data) || R.isEmpty(data)) return []
 
@@ -313,6 +312,16 @@ const EchartsPlot = ({
   const getNumberFormat = (labelKey, value) =>
     NumberFormat.format(value, numberFormat[labelKey])
 
+  const sortParams = (params) => {
+    const handleByValue =
+      chartHoverOrder === 'valueAsc' || chartHoverOrder === 'valueDesc'
+        ? R.sortBy(({ value }) => value)(params)
+        : params
+    return chartHoverOrder === 'valueAsc' || chartHoverOrder === 'seriesAsc'
+      ? handleByValue.reverse()
+      : handleByValue
+  }
+
   const options = {
     grid: distribution
       ? {
@@ -336,7 +345,7 @@ const EchartsPlot = ({
         ? {
             formatter: (params) =>
               `<div style="margin-bottom: 3px"><strong>${params[0].name}</strong></div>
-                ${params
+                ${sortParams(params)
                   .map(({ marker, seriesId, seriesName, value }) =>
                     R.isNil(value) && !showNA
                       ? false
@@ -364,7 +373,7 @@ const EchartsPlot = ({
                   .filter(R.identity)
                   .join('')}`
                 : `<div style="margin-bottom: 3px"><strong>${params[0].name}</strong></div>
-                ${params
+                ${sortParams(params)
                   .map(({ marker, seriesName, value }) =>
                     R.isNil(value) && !showNA
                       ? false
@@ -380,7 +389,7 @@ const EchartsPlot = ({
     ...lineMap,
   }
 
-  return <FlexibleChart {...{ options }} />
+  return <FlexibleChart {...{ options, chartHoverOrder }} />
 }
 
 export default EchartsPlot

--- a/src/ui/charts/chart-types/echarts/BoxPlot.js
+++ b/src/ui/charts/chart-types/echarts/BoxPlot.js
@@ -43,6 +43,7 @@ const EchartsBoxPlot = ({
   numberFormat,
   colors,
   showNA,
+  chartHoverOrder,
 }) => {
   if (R.isNil(data) || R.isEmpty(data)) return []
 
@@ -168,7 +169,7 @@ const EchartsBoxPlot = ({
     },
   }
 
-  return <FlexibleChart {...{ options }} />
+  return <FlexibleChart {...{ options, chartHoverOrder }} />
 }
 
 export { EchartsBoxPlot as BoxPlot }

--- a/src/ui/charts/chart-types/echarts/BubblePlot.js
+++ b/src/ui/charts/chart-types/echarts/BubblePlot.js
@@ -9,7 +9,13 @@ import {
   getChartItemColor,
 } from '../../../../utils'
 
-const BubblePlot = ({ data, labelProps, numberFormat, colors }) => {
+const BubblePlot = ({
+  data,
+  labelProps,
+  numberFormat,
+  colors,
+  chartHoverOrder,
+}) => {
   const labels = R.pluck('label')(labelProps)
   if (
     R.isNil(data) ||
@@ -117,7 +123,7 @@ const BubblePlot = ({ data, labelProps, numberFormat, colors }) => {
     },
   }
 
-  return <FlexibleChart {...{ options }} />
+  return <FlexibleChart {...{ options, chartHoverOrder }} />
 }
 
 export { BubblePlot }

--- a/src/ui/charts/chart-types/echarts/CumulativeLineChart.js
+++ b/src/ui/charts/chart-types/echarts/CumulativeLineChart.js
@@ -11,6 +11,7 @@ const CumulativeLineChart = ({
   numberFormat,
   colors,
   showNA,
+  chartHoverOrder,
 }) => {
   const yValues = R.has('children', R.head(data))
     ? R.pluck('children', data)
@@ -55,7 +56,14 @@ const CumulativeLineChart = ({
     <EchartsPlot
       data={accumulate(data)}
       chartType="line"
-      {...{ xAxisTitle, yAxisTitle, numberFormat, colors, showNA }}
+      {...{
+        xAxisTitle,
+        yAxisTitle,
+        numberFormat,
+        colors,
+        showNA,
+        chartHoverOrder,
+      }}
     />
   )
 }

--- a/src/ui/charts/chart-types/echarts/DistributionChart.js
+++ b/src/ui/charts/chart-types/echarts/DistributionChart.js
@@ -35,6 +35,7 @@ const DistributionChart = ({
   counts,
   stack = false,
   area = false,
+  chartHoverOrder,
 }) => {
   const [numBuckets, setNumBuckets] = useState(10)
 
@@ -141,7 +142,15 @@ const DistributionChart = ({
         data={calcDistributionData}
         seriesObj={area ? { areaStyle: { opacity: 1 }, smooth: !stack } : {}}
         xAxisTitle={yAxisTitle}
-        {...{ numberFormat, stack, colors, xAxisTitle, yAxisTitle, chartType }}
+        {...{
+          numberFormat,
+          stack,
+          colors,
+          xAxisTitle,
+          yAxisTitle,
+          chartType,
+          chartHoverOrder,
+        }}
       />
       <Box
         sx={{

--- a/src/ui/charts/chart-types/echarts/Heatmap.js
+++ b/src/ui/charts/chart-types/echarts/Heatmap.js
@@ -4,7 +4,13 @@ import { FlexibleChart } from './BaseChart'
 
 import { NumberFormat, findSubgroupLabels, getMinMax } from '../../../../utils'
 
-const Heatmap = ({ data, xAxisTitle, yAxisTitle, numberFormat }) => {
+const Heatmap = ({
+  data,
+  xAxisTitle,
+  yAxisTitle,
+  numberFormat,
+  chartHoverOrder,
+}) => {
   if (R.isNil(data) || R.isEmpty(data)) return []
 
   const xLabels = R.pluck('name', data)
@@ -82,7 +88,7 @@ const Heatmap = ({ data, xAxisTitle, yAxisTitle, numberFormat }) => {
     },
   }
 
-  return <FlexibleChart {...{ options }} />
+  return <FlexibleChart {...{ options, chartHoverOrder }} />
 }
 
 export { Heatmap }

--- a/src/ui/charts/chart-types/echarts/LinePlot.js
+++ b/src/ui/charts/chart-types/echarts/LinePlot.js
@@ -16,13 +16,22 @@ const LinePlot = ({
   stack = false,
   area = false,
   showNA,
+  chartHoverOrder,
 }) => {
   return (
     <EchartsPlot
       data={data}
       chartType="line"
       seriesObj={area ? { areaStyle: { opacity: 1 }, smooth: !stack } : {}}
-      {...{ xAxisTitle, yAxisTitle, numberFormat, stack, colors, showNA }}
+      {...{
+        xAxisTitle,
+        yAxisTitle,
+        numberFormat,
+        stack,
+        colors,
+        showNA,
+        chartHoverOrder,
+      }}
     />
   )
 }

--- a/src/ui/charts/chart-types/echarts/MixedChart.js
+++ b/src/ui/charts/chart-types/echarts/MixedChart.js
@@ -35,7 +35,7 @@ const MixedChart = ({
   labelProps,
   leftVariant,
   rightVariant,
-  orderBySize,
+  chartHoverOrder,
 }) => {
   const [syncAxes, setSyncAxes] = useState(true)
   const hasSubgroups = R.has('children', R.head(data))
@@ -206,7 +206,7 @@ const MixedChart = ({
   }
   return (
     <>
-      <FlexibleChart {...{ options, orderBySize }} />
+      <FlexibleChart {...{ options, chartHoverOrder }} />
       <FormControlLabel
         sx={{ position: 'absolute', right: 65, top: 10 }}
         control={

--- a/src/ui/charts/chart-types/echarts/MixedChart.js
+++ b/src/ui/charts/chart-types/echarts/MixedChart.js
@@ -30,7 +30,13 @@ const getData = (index, variant, data) => {
   return isCumulative(variant, values) ? accumulate(values) : values
 }
 
-const MixedChart = ({ data, labelProps, leftVariant, rightVariant }) => {
+const MixedChart = ({
+  data,
+  labelProps,
+  leftVariant,
+  rightVariant,
+  orderBySize,
+}) => {
   const [syncAxes, setSyncAxes] = useState(true)
   const hasSubgroups = R.has('children', R.head(data))
   const xLabels = R.pluck('name', data)
@@ -200,7 +206,7 @@ const MixedChart = ({ data, labelProps, leftVariant, rightVariant }) => {
   }
   return (
     <>
-      <FlexibleChart {...{ options }} />
+      <FlexibleChart {...{ options, orderBySize }} />
       <FormControlLabel
         sx={{ position: 'absolute', right: 65, top: 10 }}
         control={

--- a/src/ui/charts/chart-types/echarts/ScatterPlot.js
+++ b/src/ui/charts/chart-types/echarts/ScatterPlot.js
@@ -9,7 +9,13 @@ import {
   getChartItemColor,
 } from '../../../../utils'
 
-const ScatterPlot = ({ data, labelProps, numberFormat, colors }) => {
+const ScatterPlot = ({
+  data,
+  labelProps,
+  numberFormat,
+  colors,
+  chartHoverOrder,
+}) => {
   const labels = R.pluck('label')(labelProps)
   if (
     R.isNil(data) ||
@@ -93,7 +99,7 @@ const ScatterPlot = ({ data, labelProps, numberFormat, colors }) => {
     },
   }
 
-  return <FlexibleChart {...{ options }} />
+  return <FlexibleChart {...{ options, chartHoverOrder }} />
 }
 
 export { ScatterPlot }

--- a/src/ui/charts/chart-types/echarts/Sunburst.js
+++ b/src/ui/charts/chart-types/echarts/Sunburst.js
@@ -10,7 +10,7 @@ import {
 
 // import { exampleNestedData } from './testData'
 
-const Sunburst = ({ data, colors, numberFormat }) => {
+const Sunburst = ({ data, colors, numberFormat, chartHoverOrder }) => {
   const findNames = (data) =>
     R.has('children', R.head(data))
       ? R.map((d) => R.prepend(R.prop('name', d), findNames(d.children)), data)
@@ -110,7 +110,7 @@ const Sunburst = ({ data, colors, numberFormat }) => {
     },
   }
 
-  return <FlexibleChart {...{ options }} />
+  return <FlexibleChart {...{ options, chartHoverOrder }} />
 }
 
 export { Sunburst }

--- a/src/ui/charts/chart-types/echarts/Treemap.js
+++ b/src/ui/charts/chart-types/echarts/Treemap.js
@@ -10,7 +10,7 @@ import {
 
 // import { exampleNestedData } from './testData'
 
-const Treemap = ({ data, colors, numberFormat }) => {
+const Treemap = ({ data, colors, numberFormat, chartHoverOrder }) => {
   const findNames = (data) =>
     R.has('children', R.head(data))
       ? R.map((d) => R.prepend(R.prop('name', d), findNames(d.children)), data)
@@ -130,7 +130,7 @@ const Treemap = ({ data, colors, numberFormat }) => {
     },
   }
 
-  return <FlexibleChart {...{ options }} />
+  return <FlexibleChart {...{ options, chartHoverOrder }} />
 }
 
 export { Treemap }

--- a/src/ui/charts/chart-types/echarts/WaterfallChart.js
+++ b/src/ui/charts/chart-types/echarts/WaterfallChart.js
@@ -67,6 +67,7 @@ const WaterfallChart = ({
   numberFormat,
   colors,
   showNA,
+  chartHoverOrder,
 }) => {
   if (R.isNil(data) || R.isEmpty(data)) return []
 
@@ -245,7 +246,7 @@ const WaterfallChart = ({
     series,
   }
 
-  return <FlexibleChart {...{ options }} />
+  return <FlexibleChart {...{ options, chartHoverOrder }} />
 }
 
 const StackedWaterfallChart = ({
@@ -255,6 +256,7 @@ const StackedWaterfallChart = ({
   numberFormat,
   colors,
   showNA,
+  chartHoverOrder,
 }) => {
   if (R.isNil(data) || R.isEmpty(data)) return []
 
@@ -592,7 +594,7 @@ const StackedWaterfallChart = ({
     },
   }
 
-  return <FlexibleChart {...{ options }} />
+  return <FlexibleChart {...{ options, chartHoverOrder }} />
 }
 
 export { WaterfallChart, StackedWaterfallChart }

--- a/src/ui/views/dashboard/ChartMenu.js
+++ b/src/ui/views/dashboard/ChartMenu.js
@@ -85,6 +85,8 @@ const ChartMenu = ({
   onShowToolbar,
   onRemoveChart,
   onToggleMaximize,
+  orderBySize,
+  onChartHover,
 }) => {
   const editLayoutMode = useSelector(selectEditLayoutMode)
   const { anchorEl, handleOpenMenu, handleCloseMenu } = useMenu()
@@ -132,6 +134,11 @@ const ChartMenu = ({
           label="Show Toolbar"
           value={showToolbar}
           onClick={onShowToolbar}
+        />
+        <ToggleMenuItem
+          label="Order By Size"
+          value={orderBySize}
+          onClick={onChartHover}
         />
         <BaseMenuItem
           label={isMaximized ? 'Minimize' : 'Maximize'}

--- a/src/ui/views/dashboard/ChartMenu.js
+++ b/src/ui/views/dashboard/ChartMenu.js
@@ -4,9 +4,12 @@ import {
   Divider,
   FormControlLabel,
   FormGroup,
+  FormLabel,
   Grid,
   Menu,
   MenuItem,
+  Radio,
+  RadioGroup,
   Switch,
 } from '@mui/material'
 import { memo } from 'react'
@@ -85,7 +88,7 @@ const ChartMenu = ({
   onShowToolbar,
   onRemoveChart,
   onToggleMaximize,
-  orderBySize,
+  chartHoverOrder,
   onChartHover,
 }) => {
   const editLayoutMode = useSelector(selectEditLayoutMode)
@@ -135,16 +138,43 @@ const ChartMenu = ({
           value={showToolbar}
           onClick={onShowToolbar}
         />
-        <ToggleMenuItem
-          label="Order By Size"
-          value={orderBySize}
-          onClick={onChartHover}
-        />
         <BaseMenuItem
           label={isMaximized ? 'Minimize' : 'Maximize'}
           ReactIcon={isMaximized ? MdFullscreenExit : MdFullscreen}
           onClick={handleEventAndCloseMenu(onToggleMaximize)}
         />
+        <Divider />
+        <FormLabel sx={{ ml: 2 }}>Chart Hover</FormLabel>
+        <RadioGroup
+          sx={{ ml: 2 }}
+          value={chartHoverOrder}
+          onChange={onChartHover}
+        >
+          <FormControlLabel
+            size="small"
+            value="seriesAsc"
+            control={<Radio />}
+            label="Alphabetical Asc."
+          />
+          <FormControlLabel
+            size="small"
+            value="seriesDesc"
+            control={<Radio />}
+            label="Alphabetical Desc."
+          />
+          <FormControlLabel
+            size="small"
+            value="valueAsc"
+            control={<Radio />}
+            label="Value Asc."
+          />
+          <FormControlLabel
+            size="small"
+            value="valueDesc"
+            control={<Radio />}
+            label="Value Desc."
+          />
+        </RadioGroup>
         <Divider />
         {isGroupedOutput && [
           <ToggleMenuItem

--- a/src/ui/views/dashboard/ChartMenu.js
+++ b/src/ui/views/dashboard/ChartMenu.js
@@ -6,13 +6,18 @@ import {
   FormGroup,
   FormLabel,
   Grid,
+  Select,
   Menu,
   MenuItem,
-  Radio,
-  RadioGroup,
   Switch,
 } from '@mui/material'
 import { memo } from 'react'
+import {
+  FaSortNumericUp,
+  FaSortNumericDown,
+  FaSortAlphaDown,
+  FaSortAlphaUp,
+} from 'react-icons/fa'
 import {
   MdClose,
   MdFullscreen,
@@ -145,36 +150,20 @@ const ChartMenu = ({
         />
         <Divider />
         <FormLabel sx={{ ml: 2 }}>Chart Hover</FormLabel>
-        <RadioGroup
-          sx={{ ml: 2 }}
-          value={chartHoverOrder}
-          onChange={onChartHover}
-        >
-          <FormControlLabel
-            size="small"
-            value="seriesAsc"
-            control={<Radio />}
-            label="Alphabetical Asc."
-          />
-          <FormControlLabel
-            size="small"
-            value="seriesDesc"
-            control={<Radio />}
-            label="Alphabetical Desc."
-          />
-          <FormControlLabel
-            size="small"
-            value="valueAsc"
-            control={<Radio />}
-            label="Value Asc."
-          />
-          <FormControlLabel
-            size="small"
-            value="valueDesc"
-            control={<Radio />}
-            label="Value Desc."
-          />
-        </RadioGroup>
+        <Select value={chartHoverOrder} onChange={onChartHover} sx={{ ml: 2 }}>
+          <MenuItem value="seriesAsc">
+            <FaSortAlphaDown fontSize={20} /> Name
+          </MenuItem>
+          <MenuItem value="seriesDesc">
+            <FaSortAlphaUp fontSize={20} /> Name
+          </MenuItem>
+          <MenuItem value="valueAsc">
+            <FaSortNumericDown fontSize={20} /> Value
+          </MenuItem>
+          <MenuItem value="valueDesc">
+            <FaSortNumericUp fontSize={20} /> Value
+          </MenuItem>
+        </Select>
         <Divider />
         {isGroupedOutput && [
           <ToggleMenuItem

--- a/src/ui/views/dashboard/Dashboard.js
+++ b/src/ui/views/dashboard/Dashboard.js
@@ -88,17 +88,18 @@ const DashboardItem = ({ chartObj, index, path }) => {
   const vizType = R.propOr('groupedOutput', 'type')(chartObj)
   const defaultToZero = R.propOr(false, 'defaultToZero')(chartObj)
   const showNA = R.propOr(false, 'showNA')(chartObj)
-  const orderBySize = R.propOr(false, 'orderBySize')(chartObj)
+  const chartHoverOrder = R.propOr('seriesDesc', 'chartHoverOrder')(chartObj)
 
   // Allow session_mutate to perform non-object value update
   const handleChartHover = useMutateState(
-    () => ({
+    (event) => ({
       path,
-      value: R.assoc('orderBySize', !orderBySize)(chartObj),
+      value: R.assoc('chartHoverOrder', event.target.value)(chartObj),
       sync: !includesPath(R.values(sync), path),
     }),
-    [orderBySize, sync, chartObj, path]
+    [chartHoverOrder, sync, chartObj, path]
   )
+
   const handleShowToolbar = useMutateState(
     () => ({
       path,
@@ -231,7 +232,7 @@ const DashboardItem = ({ chartObj, index, path }) => {
       )}
       {!lockedLayout && !chartObj.lockedLayout && (
         <ChartMenu
-          {...{ isMaximized, showToolbar, orderBySize }}
+          {...{ isMaximized, showToolbar, chartHoverOrder }}
           onRemoveChart={handleRemoveChart}
           onToggleMaximize={handleToggleMaximize}
           onShowToolbar={handleShowToolbar}

--- a/src/ui/views/dashboard/Dashboard.js
+++ b/src/ui/views/dashboard/Dashboard.js
@@ -88,8 +88,17 @@ const DashboardItem = ({ chartObj, index, path }) => {
   const vizType = R.propOr('groupedOutput', 'type')(chartObj)
   const defaultToZero = R.propOr(false, 'defaultToZero')(chartObj)
   const showNA = R.propOr(false, 'showNA')(chartObj)
+  const orderBySize = R.propOr(false, 'orderBySize')(chartObj)
 
   // Allow session_mutate to perform non-object value update
+  const handleChartHover = useMutateState(
+    () => ({
+      path,
+      value: R.assoc('orderBySize', !orderBySize)(chartObj),
+      sync: !includesPath(R.values(sync), path),
+    }),
+    [orderBySize, sync, chartObj, path]
+  )
   const handleShowToolbar = useMutateState(
     () => ({
       path,
@@ -222,7 +231,7 @@ const DashboardItem = ({ chartObj, index, path }) => {
       )}
       {!lockedLayout && !chartObj.lockedLayout && (
         <ChartMenu
-          {...{ isMaximized, showToolbar }}
+          {...{ isMaximized, showToolbar, orderBySize }}
           onRemoveChart={handleRemoveChart}
           onToggleMaximize={handleToggleMaximize}
           onShowToolbar={handleShowToolbar}
@@ -231,6 +240,7 @@ const DashboardItem = ({ chartObj, index, path }) => {
           showNA={showNA}
           onToggleShowNA={handleToggleShowNA}
           isGroupedOutput={vizType === 'groupedOutput'}
+          onChartHover={handleChartHover}
         />
       )}
       {vizType === 'groupedOutput' ? (

--- a/src/ui/views/dashboard/DashboardChart.js
+++ b/src/ui/views/dashboard/DashboardChart.js
@@ -71,6 +71,7 @@ const DashboardChart = ({ chartObj }) => {
   const leftVariant = R.propOr('line', 'leftVariant', cleanedChartObj)
   const rightVariant = R.propOr('bar', 'rightVariant', cleanedChartObj)
   const showNA = R.propOr(false, 'showNA', cleanedChartObj)
+  const orderBySize = R.propOr(false, 'orderBySize')(chartObj)
 
   // for some reason useLayoutEffect doesn't set the state before the chart is rendered
   // so we use useMemo to trigger the loading state
@@ -348,7 +349,7 @@ const DashboardChart = ({ chartObj }) => {
       ) : cleanedChartObj.chartType === chartVariant.MIXED ? (
         <MixedChart
           data={formattedData}
-          {...{ labelProps }}
+          {...{ labelProps, orderBySize }}
           leftVariant={leftVariant}
           rightVariant={rightVariant}
         />

--- a/src/ui/views/dashboard/DashboardChart.js
+++ b/src/ui/views/dashboard/DashboardChart.js
@@ -71,7 +71,7 @@ const DashboardChart = ({ chartObj }) => {
   const leftVariant = R.propOr('line', 'leftVariant', cleanedChartObj)
   const rightVariant = R.propOr('bar', 'rightVariant', cleanedChartObj)
   const showNA = R.propOr(false, 'showNA', cleanedChartObj)
-  const orderBySize = R.propOr(false, 'orderBySize')(chartObj)
+  const chartHoverOrder = R.propOr('seriesDesc', 'chartHoverOrder')(chartObj)
 
   // for some reason useLayoutEffect doesn't set the state before the chart is rendered
   // so we use useMemo to trigger the loading state
@@ -266,69 +266,78 @@ const DashboardChart = ({ chartObj }) => {
       ) : cleanedChartObj.chartType === chartVariant.BOX_PLOT ? (
         <BoxPlot
           data={formattedData}
-          {...{ colors, numberFormat, showNA, ...labels }}
+          {...{ colors, numberFormat, showNA, chartHoverOrder, ...labels }}
         />
       ) : cleanedChartObj.chartType === chartVariant.BAR ? (
         <BarPlot
           data={formattedData}
-          {...{ colors, numberFormat, showNA, ...labels }}
+          {...{ colors, numberFormat, showNA, chartHoverOrder, ...labels }}
         />
       ) : cleanedChartObj.chartType === chartVariant.STACKED_BAR ? (
         <BarPlot
           stack="x"
           data={formattedData}
-          {...{ colors, numberFormat, showNA, ...labels }}
+          {...{ colors, numberFormat, showNA, chartHoverOrder, ...labels }}
         />
       ) : cleanedChartObj.chartType === chartVariant.STACKED_WATERFALL ? (
         <StackedWaterfallChart
           data={formattedData}
-          {...{ colors, numberFormat, showNA, ...labels }}
+          {...{ colors, numberFormat, showNA, chartHoverOrder, ...labels }}
         />
       ) : cleanedChartObj.chartType === chartVariant.LINE ? (
         <LinePlot
           data={formattedData}
-          {...{ colors, numberFormat, showNA, ...labels }}
+          {...{ colors, numberFormat, showNA, chartHoverOrder, ...labels }}
         />
       ) : cleanedChartObj.chartType === chartVariant.WATERFALL ? (
         <WaterfallChart
           data={formattedData}
-          {...{ colors, numberFormat, showNA, ...labels }}
+          {...{ colors, numberFormat, showNA, chartHoverOrder, ...labels }}
         />
       ) : cleanedChartObj.chartType === chartVariant.CUMULATIVE_LINE ? (
         <CumulativeLineChart
           data={formattedData}
-          {...{ colors, numberFormat, showNA, ...labels }}
+          {...{ colors, numberFormat, showNA, chartHoverOrder, ...labels }}
         />
       ) : cleanedChartObj.chartType === chartVariant.SUNBURST ? (
-        <Sunburst data={formattedData} {...{ colors, numberFormat }} />
+        <Sunburst
+          data={formattedData}
+          {...{ colors, numberFormat, chartHoverOrder }}
+        />
       ) : cleanedChartObj.chartType === chartVariant.TREEMAP ? (
-        <Treemap data={formattedData} {...{ colors, numberFormat }} />
+        <Treemap
+          data={formattedData}
+          {...{ colors, numberFormat, chartHoverOrder }}
+        />
       ) : cleanedChartObj.chartType === chartVariant.GAUGE ? (
         <GaugeChart
           data={formattedData}
           {...{ colors, numberFormat, ...labels }}
         />
       ) : cleanedChartObj.chartType === chartVariant.HEATMAP ? (
-        <Heatmap data={formattedData} {...{ numberFormat, ...labels }} />
+        <Heatmap
+          data={formattedData}
+          {...{ numberFormat, chartHoverOrder, ...labels }}
+        />
       ) : cleanedChartObj.chartType === chartVariant.AREA ? (
         <LinePlot
           area
           data={formattedData}
-          {...{ colors, numberFormat, showNA, ...labels }}
+          {...{ colors, numberFormat, showNA, chartHoverOrder, ...labels }}
         />
       ) : cleanedChartObj.chartType === chartVariant.STACKED_AREA ? (
         <LinePlot
           area
           stack="x"
           data={formattedData}
-          {...{ colors, numberFormat, showNA, ...labels }}
+          {...{ colors, numberFormat, showNA, chartHoverOrder, ...labels }}
         />
       ) : cleanedChartObj.chartType === chartVariant.SCATTER &&
         R.isNil(R.path(['statId', 2], cleanedChartObj)) ? (
         <ScatterPlot
           data={formattedData}
           labelProps={R.dissoc(3)(labelProps)}
-          {...{ colors, numberFormat }}
+          {...{ colors, numberFormat, chartHoverOrder }}
         />
       ) : cleanedChartObj.chartType === chartVariant.DISTRIBUTION ? (
         <DistributionChart
@@ -344,19 +353,19 @@ const DashboardChart = ({ chartObj }) => {
                 : 'Cumulative Density'
           }
           xAxisTitle={yAxisTitle}
-          {...{ colors, numberFormat }}
+          {...{ colors, numberFormat, chartHoverOrder }}
         />
       ) : cleanedChartObj.chartType === chartVariant.MIXED ? (
         <MixedChart
           data={formattedData}
-          {...{ labelProps, orderBySize }}
+          {...{ labelProps, chartHoverOrder }}
           leftVariant={leftVariant}
           rightVariant={rightVariant}
         />
       ) : cleanedChartObj.chartType === chartVariant.SCATTER ? (
         <BubblePlot
           data={formattedData}
-          {...{ labelProps, colors, numberFormat }}
+          {...{ labelProps, colors, numberFormat, chartHoverOrder }}
         />
       ) : (
         <></>


### PR DESCRIPTION
Allow sorting the items in the chart hover box by alphabetical order or value, either ascending or descending, using a radio selector in the chart menu.

![Screenshot (407)](https://github.com/user-attachments/assets/e5e4ca73-9dbb-4043-89ba-e406c9964358)

Resolves #576 